### PR TITLE
Fix #64: Cache follow-up cleanup and lifecycle coverage

### DIFF
--- a/diagram-designer-api/src/main/java/com/example/diagramdesigner/config/CacheProperties.java
+++ b/diagram-designer-api/src/main/java/com/example/diagramdesigner/config/CacheProperties.java
@@ -10,13 +10,17 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "cache")
 public class CacheProperties {
 
-    private final Diagram diagram = new Diagram();
+    private final DiagramCache diagram = new DiagramCache();
     private final ServiceDiscovery serviceDiscovery = new ServiceDiscovery();
 
-    public Diagram getDiagram() { return diagram; }
+    public DiagramCache getDiagramCache() { return diagram; }
+
+    @Deprecated
+    public DiagramCache getDiagram() { return diagram; }
+
     public ServiceDiscovery getServiceDiscovery() { return serviceDiscovery; }
 
-    public static class Diagram {
+    public static class DiagramCache {
         @Min(1)
         private int maxSize = 64;
 

--- a/diagram-designer-api/src/main/java/com/example/diagramdesigner/controller/DiagramController.java
+++ b/diagram-designer-api/src/main/java/com/example/diagramdesigner/controller/DiagramController.java
@@ -56,8 +56,8 @@ public class DiagramController {
         this.diagramService = diagramService;
         this.configsDirectoryResolver = configsDirectoryResolver;
         this.configCache = Caffeine.newBuilder()
-                .maximumSize(cacheProperties.getDiagram().getMaxSize())
-                .expireAfterWrite(Duration.ofSeconds(cacheProperties.getDiagram().getTtlSeconds()))
+                .maximumSize(cacheProperties.getDiagramCache().getMaxSize())
+                .expireAfterWrite(Duration.ofSeconds(cacheProperties.getDiagramCache().getTtlSeconds()))
                 .build();
     }
 

--- a/diagram-designer-api/src/main/resources/application.yml
+++ b/diagram-designer-api/src/main/resources/application.yml
@@ -59,6 +59,13 @@ spring:
   config:
     activate:
       on-profile: dev
+  datasource:
+    url: jdbc:sqlite:./diagrams.db
+    driver-class-name: org.sqlite.JDBC
+  jpa:
+    database-platform: org.sqlite.hibernate.dialect.SQLiteDialect
+  flyway:
+    locations: classpath:db/migration/sqlite
 
 server:
   port: 3001

--- a/diagram-designer-api/src/test/java/com/example/diagramdesigner/controller/DiagramControllerCacheTest.java
+++ b/diagram-designer-api/src/test/java/com/example/diagramdesigner/controller/DiagramControllerCacheTest.java
@@ -7,18 +7,10 @@ import com.example.diagramdesigner.service.DiagramService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DiagramControllerCacheTest {
@@ -35,9 +27,6 @@ class DiagramControllerCacheTest {
     private CacheProperties cacheProperties;
     private DiagramController controller;
 
-    @TempDir
-    Path tempDir;
-
     @BeforeEach
     void setUp() {
         cacheProperties = new CacheProperties();
@@ -45,37 +34,19 @@ class DiagramControllerCacheTest {
     }
 
     @Test
-    void cacheHitAvoidReprocessingForUnchangedFile() throws Exception {
-        // Create a test config file in a "configs" directory
-        Path configsDir = tempDir.resolve("configs");
-        Files.createDirectories(configsDir);
-        Path configFile = configsDir.resolve("test.json");
-        Files.writeString(configFile, "{\"nodes\": []}");
-
-        when(configurationProcessor.processVariableSubstitution(anyString()))
-                .thenReturn("{\"nodes\": [\"processed\"]}");
-
-        // Use the controller — since it looks for configs in specific paths,
-        // we test the cache logic through a fresh controller that uses CacheProperties defaults
-        // The default values should match what was previously hardcoded
-        assertEquals(64, cacheProperties.getDiagram().getMaxSize());
-        assertEquals(600, cacheProperties.getDiagram().getTtlSeconds());
-    }
-
-    @Test
     void cachePropertiesDefaultsMatchPreviousHardcodedValues() {
-        assertEquals(64, cacheProperties.getDiagram().getMaxSize());
-        assertEquals(600, cacheProperties.getDiagram().getTtlSeconds());
+        assertEquals(64, cacheProperties.getDiagramCache().getMaxSize());
+        assertEquals(600, cacheProperties.getDiagramCache().getTtlSeconds());
     }
 
     @Test
     void cachePropertiesAreConfigurable() {
-        cacheProperties.getDiagram().setMaxSize(32);
-        cacheProperties.getDiagram().setTtlSeconds(120);
+        cacheProperties.getDiagramCache().setMaxSize(32);
+        cacheProperties.getDiagramCache().setTtlSeconds(120);
 
         DiagramController customController = new DiagramController(configurationProcessor, diagramService, configsDirectoryResolver, cacheProperties);
         assertNotNull(customController);
-        assertEquals(32, cacheProperties.getDiagram().getMaxSize());
-        assertEquals(120, cacheProperties.getDiagram().getTtlSeconds());
+        assertEquals(32, cacheProperties.getDiagramCache().getMaxSize());
+        assertEquals(120, cacheProperties.getDiagramCache().getTtlSeconds());
     }
 }

--- a/diagram-designer-api/src/test/java/com/example/diagramdesigner/model/DiagramLifecycleTest.java
+++ b/diagram-designer-api/src/test/java/com/example/diagramdesigner/model/DiagramLifecycleTest.java
@@ -1,0 +1,37 @@
+package com.example.diagramdesigner.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DiagramLifecycleTest {
+
+    @Test
+    void onCreateSetsCreatedAtAndUpdatedAt() {
+        Diagram diagram = new Diagram();
+
+        diagram.onCreate();
+
+        assertNotNull(diagram.getCreatedAt());
+        assertNotNull(diagram.getUpdatedAt());
+    }
+
+    @Test
+    void onUpdateRefreshesUpdatedAt() {
+        Diagram diagram = new Diagram();
+
+        LocalDateTime originalCreatedAt = LocalDateTime.now().minusMinutes(2);
+        LocalDateTime originalUpdatedAt = LocalDateTime.now().minusMinutes(1);
+        diagram.setCreatedAt(originalCreatedAt);
+        diagram.setUpdatedAt(originalUpdatedAt);
+
+        diagram.onUpdate();
+
+        assertEquals(originalCreatedAt, diagram.getCreatedAt());
+        assertTrue(diagram.getUpdatedAt().isAfter(originalUpdatedAt));
+    }
+}


### PR DESCRIPTION
## Summary
- rename cache config nested type to `DiagramCache` in `CacheProperties` to avoid model-name ambiguity
- update `DiagramController` and cache tests to use `getDiagramCache()`
- add explicit SQLite datasource/JPA/Flyway entries under the `dev` profile in `application.yml`
- add `DiagramLifecycleTest` to cover `@PrePersist`/`@PreUpdate` timestamp lifecycle behavior
- clean up `DiagramControllerCacheTest` to remove ineffective stubbing and keep focused assertions

## Verification
- `./mvnw -pl diagram-designer-api -Dexec.skip=true -Dtest=DiagramLifecycleTest,DiagramControllerCacheTest,MetricsProxyServiceTest,AuthenticationResolverTest test`

Fixes #64
